### PR TITLE
Disable nyurikThatSrcEnable locally

### DIFF
--- a/wbstack/data/WikiInfo-site1.json
+++ b/wbstack/data/WikiInfo-site1.json
@@ -70,7 +70,7 @@
       {
         "id": 6,
         "name": "nyurikThatSrcEnable",
-        "value": "1",
+        "value": "0",
         "wiki_id": 1,
         "created_at": "2021-01-01 10:10:10",
         "updated_at": "2021-01-01 10:10:10"

--- a/wbstack/data/WikiInfo-site2.json
+++ b/wbstack/data/WikiInfo-site2.json
@@ -70,7 +70,7 @@
       {
         "id": 6,
         "name": "nyurikThatSrcEnable",
-        "value": "1",
+        "value": "0",
         "wiki_id": 2,
         "created_at": "2021-01-01 10:10:10",
         "updated_at": "2021-01-01 10:10:10"


### PR DESCRIPTION
This seems to interfere with the ui getting loaded for wikibase/lexemes
when enabled on the local mutli-site setup.

Error: Unknown module: jquery.valueview.experts is thrown when the js ui
is supposed to startup.