### PR TITLE
Configure elasticsearch for WikibaseLexeme

### DIFF
--- a/wbstack/CHANGELOG.md
+++ b/wbstack/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Tags have the format: `<MediaWiki core version>-<PHP Version>-<date>-<build number>`
 
+## 1.35-7.4-20210824-0
+
+- [Configure elasticsearch for WikibaseLexeme](https://github.com/wbstack/mediawiki/pull/121)
+
 ## 1.35-7.4-20210803-2
 
 - `$wgEnableDnsBlacklist = true;`

--- a/wbstack/README.md
+++ b/wbstack/README.md
@@ -113,3 +113,17 @@ Wait until both sites are accessible:
 curl -l -X POST "http://site1.localhost:8001/w/api.php?action=wbstackElasticSearchInit&format=json"
 curl -l -X POST "http://site2.localhost:8001/w/api.php?action=wbstackElasticSearchInit&format=json"
 ```
+
+### Debugging Elastic
+
+General overview of the cluster
+
+```
+http://localhost:9200/_stats
+```
+
+Entries in the content index (Items, Lexemes) for `site1.localhost` can be found by going to the following url
+
+```
+http://localhost:9200/site1.localhost_content_first/_search
+```

--- a/wbstack/src/Settings/LocalSettings.php
+++ b/wbstack/src/Settings/LocalSettings.php
@@ -568,9 +568,24 @@ if ( $wikiInfo->getSetting( 'wwExtEnableElasticSearch' ) ) {
     wfLoadExtension( 'CirrusSearch' );
     wfLoadExtension( 'WikibaseCirrusSearch' );
 
+    $wgWBRepoSettings['searchIndexTypes'] = [
+        'string', 'external-id', 'url', 'wikibase-item', 'wikibase-property'
+    ];
+
     // If Wikibase Lexemes are enabled, enable lexeme cirrus search
     if ( $wikiInfo->getSetting('wwExtEnableWikibaseLexeme') ) {
         wfLoadExtension('WikibaseLexemeCirrusSearch');
+
+        $wgLexemeUseCirrus = true;
+
+        // So that Lexemes are indexed in the content index
+        $wgContentNamespaces[] = 146;
+
+        // Add lexeme searchIndexTypes
+        $wgWBRepoSettings['searchIndexTypes'] = [
+            'string', 'external-id', 'url', 'wikibase-item', 'wikibase-property',
+            'wikibase-lexeme', 'wikibase-form', 'wikibase-sense'
+        ];
     }
 }
 

--- a/wbstack/src/Settings/LocalSettings.php
+++ b/wbstack/src/Settings/LocalSettings.php
@@ -582,10 +582,9 @@ if ( $wikiInfo->getSetting( 'wwExtEnableElasticSearch' ) ) {
         $wgContentNamespaces[] = 146;
 
         // Add lexeme searchIndexTypes
-        $wgWBRepoSettings['searchIndexTypes'] = [
-            'string', 'external-id', 'url', 'wikibase-item', 'wikibase-property',
-            'wikibase-lexeme', 'wikibase-form', 'wikibase-sense'
-        ];
+        $wgWBRepoSettings['searchIndexTypes'][] = 'wikibase-lexeme';
+        $wgWBRepoSettings['searchIndexTypes'][] = 'wikibase-form';
+        $wgWBRepoSettings['searchIndexTypes'][] = 'wikibase-sense';
     }
 }
 


### PR DESCRIPTION
Seems we don't need to do anything special when lexeme is enabled. The terms end up in the same index with this configuration.