### PR TITLE
Use the wgDBName variable as wgCirrusSearchIndexBaseName

### DIFF
--- a/wbstack/CHANGELOG.md
+++ b/wbstack/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Tags have the format: `<MediaWiki core version>-<PHP Version>-<date>-<build number>`
 
+## To Be Released
+
+- [Use dbname in elasticsearch indexes](https://github.com/wbstack/mediawiki/pull/128)
+
 ## 1.35-7.4-20210824-0
 
 - [Configure elasticsearch for WikibaseLexeme](https://github.com/wbstack/mediawiki/pull/121)

--- a/wbstack/src/Settings/LocalSettings.php
+++ b/wbstack/src/Settings/LocalSettings.php
@@ -584,13 +584,9 @@ if ( $wikiInfo->getSetting( 'wwExtEnableElasticSearch' ) ) {
         $wgWBRepoSettings['searchIndexTypes'][] = 'wikibase-form';
         $wgWBRepoSettings['searchIndexTypes'][] = 'wikibase-sense';
     }
-}
 
-// ElasticSearch configuration
-if ( $wikiInfo->getSetting( 'wwExtEnableElasticSearch' ) ) {
-
-    // prepends indices with subdomain
-    $wgCirrusSearchIndexBaseName = $wikiInfo->requestDomain;
+    // prepends indices with database name
+    $wgCirrusSearchIndexBaseName = $wgDBname;
 
     $wgSearchType = 'CirrusSearch';
     $wgCirrusSearchDefaultCluster = 'default';


### PR DESCRIPTION
Instead of using the user specified domain we should use something
generated by the system.