### PR TITLE
Don't ignore composer platform reqs

### DIFF
--- a/wbstack/sync/04-docker-composer.sh
+++ b/wbstack/sync/04-docker-composer.sh
@@ -10,13 +10,13 @@ mkdir -p ${COMPOSER_CACHE_DIR:-$HOME/.cache/composer}
 docker run --rm -it -u $(id -u ${USER}):$(id -g ${USER}) -v $PWD:/app \
   --volume $SCRIPT_COMPOSER_CACHE:/tmp/cache \
   --entrypoint composer -w /app \
-  docker-registry.wikimedia.org/releng/composer-package-php74:0.3.0-s7 install --no-dev --no-progress --optimize-autoloader --ignore-platform-reqs
+  docker-registry.wikimedia.org/releng/composer-package-php74:0.3.0-s7 install --no-dev --no-progress --optimize-autoloader
 
 # composer update
 docker run --rm -it -u $(id -u ${USER}):$(id -g ${USER}) -v $PWD:/app \
   --volume $SCRIPT_COMPOSER_CACHE:/tmp/cache \
   --entrypoint composer -w /app \
-  docker-registry.wikimedia.org/releng/composer-package-php74:0.3.0-s7 update --no-dev --no-progress --optimize-autoloader --ignore-platform-reqs
+  docker-registry.wikimedia.org/releng/composer-package-php74:0.3.0-s7 update --no-dev --no-progress --optimize-autoloader
 
 
 # Sometimes composer git clones things rather than using zips.
@@ -24,4 +24,3 @@ docker run --rm -it -u $(id -u ${USER}):$(id -g ${USER}) -v $PWD:/app \
 # https://github.com/wbstack/mediawiki/issues/5
 echo "Cleaning up any .git directories in composer packages..."
 find ./ -mindepth 1 -regex '^./vendor/.*/.*/\.git\(/.*\)?' -delete
-


### PR DESCRIPTION
`--ignore-platform-reqs` was added here because composer refused to
update due to missing php extensions in the docker image. This problem
went away since the composer docker image we use was updated in
4a0e41b30ed9e80ec18cccb3a6af0e3f2e3dc961.

Having `--ignore-platform-reqs` now caused a problem because it means
that it also ignores the PHP version, and running `wbstack/sync.sh` on
the current main branch also pulls in PHP 8 packages which can't be used
yet.