### PR TITLE
Use /tmp instead of .tmp to tidy up directory

### DIFF
--- a/.github/workflows/wbstack.python.lint.yml
+++ b/.github/workflows/wbstack.python.lint.yml
@@ -29,4 +29,4 @@ jobs:
 
     - name: Lint wbstack directory
       working-directory: ./wbstack
-      run: find ./ -type f -name "*.py" -not -path "./sync/.tmp/*" | xargs pylint
+      run: find ./ -type f -name "*.py" | xargs pylint

--- a/wbstack/sync/pacman-script
+++ b/wbstack/sync/pacman-script
@@ -3,7 +3,12 @@
 BASEDIR=$(cd `dirname "$0"` && pwd)
 YAMLFILE="${BASEDIR}/pacman.yaml"
 REPO_DIR="${BASEDIR}/../../"
-TEMPORARY_DIR="${BASEDIR}/.tmp/"
+TEMPORARY_DIR=$(mktemp -d)/
+
+# .tmp was removed so that the files in the repo dir were cleaner.
+# This was changed in January 2022, we could remove this cleanup in the future.
+OLD_TEMPORARY_DIR="${BASEDIR}/.tmp"
+rm -rf $OLD_TEMPORARY_DIR
 
 for codebase in $(yq eval -o=j $YAMLFILE | jq -cr '.[]'); do
     # download and extract each artifact asynchronously


### PR DESCRIPTION
Having .tmp in this directory complicates things:
 - IDEs show multiple copies of code
 - It needs excluding from things like linting

So just use a system tmp directory instead
