### PR TITLE
Fix error handling in `wikiman.py`

### DIFF
--- a/sync/wikiman.py
+++ b/sync/wikiman.py
@@ -12,10 +12,7 @@ GITHUB_TOKEN_FILE = f"{BASEDIR}/.github"
 
 codebases = {}
 with open(SOURCE_YAMLFILE, "r") as filehandler:
-    try:
-        codebases = yaml.safe_load(filehandler)
-    except yaml.YAMLError as exc:
-        print(exc)
+    codebases = yaml.safe_load(filehandler)
 
 mediawiki_version = codebases['mediawikiVersion']
 extensions = codebases['extensions']


### PR DESCRIPTION
The try/except block would cause the program to print out the error and continue which would do more harm than just letting the error be raised.