### PR TITLE
Fix vendor and composer.lock in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .github
-./vendor
-./composer.lock
+/vendor
+/composer.lock
 sync/.tmp/*
 !sync/.tmp/.gitkeep


### PR DESCRIPTION
Earlier today we changed this to have ./
in front of vendor and composer.lock
This actually didn't do what we wanted!

Prior to our earlier "fix" vendor was used as a glob,
and thus caused us problems.
Adding `./` stopped it from being used as a glob, and
it ultimately didn't ignore anything.
This final patch means we ignore the files in the root
of the repo.

This wasn't noticed earlier as the dev machine we did
this on didn't have composer.lock or vendor directories
at this level.
