### PR TITLE
Fix github token .gitignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-sync/.github
+/sync/.github
 /vendor
 /composer.lock
 sync/.tmp/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.github
+sync/.github
 /vendor
 /composer.lock
 sync/.tmp/*

--- a/dist/vendor/ezimuel/ringphp/.github/workflows/test.yml
+++ b/dist/vendor/ezimuel/ringphp/.github/workflows/test.yml
@@ -1,0 +1,44 @@
+name: PHP test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php-version: [7.4, 8.0]
+        
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Use PHP ${{ matrix.php-version }}
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-version }}
+        extensions: zip, curl
+      env:
+        COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+   
+    - name: Get composer cache directory
+      id: composercache
+      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.composercache.outputs.dir }}
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+        restore-keys: ${{ runner.os }}-composer-
+
+    - name: Install dependencies
+      run: |
+        composer install --prefer-dist
+
+    - name: Unit tests
+      run: |
+        composer run-script test
+        


### PR DESCRIPTION
The entry as it was ignored things it wasn't meant to ignore, such as
the whole .github/ directory containing github actions, and other
.github directories within extensions (which probably aren't needed, but
.gitignore isn't the mechanism we want to use for this).

The random file from an extension that's added here is the result of it now not being ignored.