### PR TITLE
Make sync script exit early on failure

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -2,6 +2,9 @@
 # Syncs the whole git repo in the correct way
 # This is probably the file that you want to run..
 
+# exit when any command fails
+set -e
+
 BASEDIR=$(cd `dirname "$0"` && pwd)
 
 cd $BASEDIR

--- a/sync/pacman/pacman-script
+++ b/sync/pacman/pacman-script
@@ -3,6 +3,9 @@
 # this directory must include a pacman.yml
 # pacman will populate a dist folder in the same directory, from the pacman.yml
 
+# exit when any command fails
+set -e
+
 if [ -z "$1" ]; then
     echo "Usage: $0 <target>"
     exit 1


### PR DESCRIPTION
Right now they run until end, and due to the large
size of this repo it can sometimes be hard to see if
something broken part way through the run.
So break when things break, in a bigger and more
obvious way!

https://phabricator.wikimedia.org/T298771
