### PR TITLE
Prepare 1.37-7.4-20220118-fp-beta-0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Tags have the format: `<MediaWiki core version>-<PHP Version>-<date>-<build number>`
 
+## 1.37-7.4-20220118-fp-beta-0
+- Set $wgReadOnly from the api
+
 ## 1.37-7.4-20220105-fp-beta-0
 
 - Update extensions and skins to include latest REL1_37 changes


### PR DESCRIPTION
This includes the READONLY mode controlled by the API.

Bug: [T298759](https://phabricator.wikimedia.org/T298759)

I believe all the other changes since the last release only changed the sync code without touching the image itself.