### PR TITLE
Use escapeshellarg in WbStackForceSearchIndex

### DIFF
--- a/dist-persist/wbstack/src/Internal/ApiWbStackForceSearchIndex.php
+++ b/dist-persist/wbstack/src/Internal/ApiWbStackForceSearchIndex.php
@@ -18,7 +18,7 @@ class ApiWbStackForceSearchIndex extends \ApiBase {
         $fromId = $this->getParameter('fromId');
         $toId = $this->getParameter('toId');
 
-        $parameters = "--skipLinks 1 --indexOnSkip 1 --fromId ${fromId}  --toId ${toId}";
+        $parameters = "--skipLinks 1 --indexOnSkip 1 --fromId " . escapeshellarg( $fromId ) . " --toId " . escapeshellarg( $toId );
 		$cmd = 'WBS_DOMAIN=' . $GLOBALS[WBSTACK_INFO_GLOBAL]->requestDomain . ' php ' . $IP . '/extensions/CirrusSearch/maintenance/ForceSearchIndex.php ' . $parameters;
 		exec($cmd, $out, $return);
 

--- a/dist/wbstack/src/Internal/ApiWbStackForceSearchIndex.php
+++ b/dist/wbstack/src/Internal/ApiWbStackForceSearchIndex.php
@@ -18,7 +18,7 @@ class ApiWbStackForceSearchIndex extends \ApiBase {
         $fromId = $this->getParameter('fromId');
         $toId = $this->getParameter('toId');
 
-        $parameters = "--skipLinks 1 --indexOnSkip 1 --fromId ${fromId}  --toId ${toId}";
+        $parameters = "--skipLinks 1 --indexOnSkip 1 --fromId " . escapeshellarg( $fromId ) . " --toId " . escapeshellarg( $toId );
 		$cmd = 'WBS_DOMAIN=' . $GLOBALS[WBSTACK_INFO_GLOBAL]->requestDomain . ' php ' . $IP . '/extensions/CirrusSearch/maintenance/ForceSearchIndex.php ' . $parameters;
 		exec($cmd, $out, $return);
 


### PR DESCRIPTION
Followup to https://github.com/wbstack/mediawiki/pull/209
I went through and audited all usages, and this is the only
place that it was actually missing from.
