### PR TITLE
This catches the maintenance::fatalError exit that happens when no pages

### DIFF
--- a/dist-persist/wbstack/src/Internal/ApiWbStackQueueSearchIndexBatches.php
+++ b/dist-persist/wbstack/src/Internal/ApiWbStackQueueSearchIndexBatches.php
@@ -16,7 +16,7 @@ class ApiWbStackQueueSearchIndexBatches extends \ApiBase {
 		@ini_set( 'memory_limit', '-1' ); // also try to disable the memory limit? Is this even a good idea?
 		
         $parameters = "--skipLinks --indexOnSkip --buildChunks 10000";
-		$cmd = 'WBS_DOMAIN=' . $GLOBALS[WBSTACK_INFO_GLOBAL]->requestDomain . ' php ' . $IP . '/extensions/CirrusSearch/maintenance/ForceSearchIndex.php ' . $parameters;
+		$cmd = 'WBS_DOMAIN=' . $GLOBALS[WBSTACK_INFO_GLOBAL]->requestDomain . ' php ' . $IP . '/extensions/CirrusSearch/maintenance/ForceSearchIndex.php ' . $parameters . ' 2>&1';
 		exec($cmd, $out, $return);
 
 		// Return appropriate result

--- a/dist/wbstack/src/Internal/ApiWbStackQueueSearchIndexBatches.php
+++ b/dist/wbstack/src/Internal/ApiWbStackQueueSearchIndexBatches.php
@@ -16,7 +16,7 @@ class ApiWbStackQueueSearchIndexBatches extends \ApiBase {
 		@ini_set( 'memory_limit', '-1' ); // also try to disable the memory limit? Is this even a good idea?
 		
         $parameters = "--skipLinks --indexOnSkip --buildChunks 10000";
-		$cmd = 'WBS_DOMAIN=' . $GLOBALS[WBSTACK_INFO_GLOBAL]->requestDomain . ' php ' . $IP . '/extensions/CirrusSearch/maintenance/ForceSearchIndex.php ' . $parameters;
+		$cmd = 'WBS_DOMAIN=' . $GLOBALS[WBSTACK_INFO_GLOBAL]->requestDomain . ' php ' . $IP . '/extensions/CirrusSearch/maintenance/ForceSearchIndex.php ' . $parameters . ' 2>&1';
 		exec($cmd, $out, $return);
 
 		// Return appropriate result


### PR DESCRIPTION
This error message was just output into the k8s log instead of the output of the `exec` call 