### PR TITLE
Make running rebuildLocalisationCache less painful

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,9 +102,10 @@ RUN set -eux; \
 COPY --chown=www-data:www-data ./dist/ /var/www/html/w
 
 # Generate localization cache files
-# TODO could run mediawiki builds on a bigger machine and make use of more threads
 # TODO it would be much better to ADD / COPY files after this? urgff.
 # or cache the output of the cache rebuild and then try to grab that during buildss!!! :D
-RUN WBS_DOMAIN=maint php ./w/maintenance/rebuildLocalisationCache.php
+ARG LOCALIZATION_CACHE_THREAD_COUNT=1
+ARG LOCALIZATION_CACHE_ADDITIONAL_PARAMS
+RUN WBS_DOMAIN=maint php ./w/maintenance/rebuildLocalisationCache.php --threads=${LOCALIZATION_CACHE_THREAD_COUNT} ${LOCALIZATION_CACHE_ADDITIONAL_PARAMS}
 
 LABEL org.opencontainers.image.source="https://github.com/wbstack/mediawiki"

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ This part describes the Docker image that this repo is designed to build. People
 - `MW_ELASTICSEARCH_PORT`: elasticsearch port
 - `MW_LOG_TO_STDERR`: set to "yes" to redirect all mediawiki logging to stderr (so it ends up in the kubernetes pod logs)
 
+## Dockerfile build arguments
+
+- `LOCALIZATION_CACHE_THREAD_COUNT`: Number of threads to use when rebuildLocalisationCache.php runs, defaults to 1
+- `LOCALIZATION_CACHE_ADDITIONAL_PARAMS` Additional parameters to pass to rebuildLocalisationCache.php, can for example be used to reduce the number of languages built.
 
 ## Instructions
 


### PR DESCRIPTION
This removes one TODO on the rebuildLocalisationCache for threading. It
also allows the languages to be specified when building. This is useful
to reduce the number of languages when building locally.