### PR TITLE
Change mediawiki patchUrls

### DIFF
--- a/pacman.yaml
+++ b/pacman.yaml
@@ -23,6 +23,8 @@
     - docs
     - extensions/README
     - skins/README
+  patchUrls:
+    - https://gerrit.wikimedia.org/r/changes/mediawiki%2Fcore~911315/revisions/1/patch?download
 - name: RevisionSlider
   artifactUrl: https://codeload.github.com/wikimedia/mediawiki-extensions-RevisionSlider/zip/454efce255d339b426b3f3abb366b46e911b95a7
   artifactLevel: 1


### PR DESCRIPTION
Point mediawiki to this [patch](https://gerrit.wikimedia.org/r/c/mediawiki/core/+/911315/) instead. This patch silence the deprecated hook `PersonalUrls`.

Bug: [T334648](https://phabricator.wikimedia.org/T334846)