### PR TITLE
Add QuestyCaptcha

### DIFF
--- a/dist-persist/wbstack/src/Settings/LocalSettings.php
+++ b/dist-persist/wbstack/src/Settings/LocalSettings.php
@@ -458,11 +458,20 @@ $wgDnsBlacklistUrls =
     ];
 
 # ConfirmEdit
-wfLoadExtensions([ 'ConfirmEdit', 'ConfirmEdit/ReCaptchaNoCaptcha' ]);
-$wgCaptchaClass = 'ReCaptchaNoCaptcha';
-$wgReCaptchaSendRemoteIP = true;
-$wgReCaptchaSiteKey = getenv('MW_RECAPTCHA_SITEKEY');
-$wgReCaptchaSecretKey = getenv('MW_RECAPTCHA_SECRETKEY');
+
+# QuestyCaptcha
+$wwUseQuestyCaptcha = $wikiInfo->getSetting('wwUseQuestyCaptcha');
+if ($wwUseQuestyCaptcha) {
+    wfLoadExtensions([ 'ConfirmEdit', 'ConfirmEdit/QuestyCaptcha' ]);
+    $wgCaptchaClass = 'QuestyCaptcha';
+    $wgCaptchaQuestions = json_decode($wikiInfo->getSetting('wwCaptchaQuestions'), true);
+} else {
+    wfLoadExtensions([ 'ConfirmEdit', 'ConfirmEdit/ReCaptchaNoCaptcha' ]);
+    $wgCaptchaClass = 'ReCaptchaNoCaptcha';
+    $wgReCaptchaSendRemoteIP = true;
+    $wgReCaptchaSiteKey = getenv('MW_RECAPTCHA_SITEKEY');
+    $wgReCaptchaSecretKey = getenv('MW_RECAPTCHA_SECRETKEY');
+}
 
 # Mailgun
 if ($wwUseMailgunExtension) {

--- a/dist/wbstack/src/Settings/LocalSettings.php
+++ b/dist/wbstack/src/Settings/LocalSettings.php
@@ -458,11 +458,20 @@ $wgDnsBlacklistUrls =
     ];
 
 # ConfirmEdit
-wfLoadExtensions([ 'ConfirmEdit', 'ConfirmEdit/ReCaptchaNoCaptcha' ]);
-$wgCaptchaClass = 'ReCaptchaNoCaptcha';
-$wgReCaptchaSendRemoteIP = true;
-$wgReCaptchaSiteKey = getenv('MW_RECAPTCHA_SITEKEY');
-$wgReCaptchaSecretKey = getenv('MW_RECAPTCHA_SECRETKEY');
+
+# QuestyCaptcha
+$wwUseQuestyCaptcha = $wikiInfo->getSetting('wwUseQuestyCaptcha');
+if ($wwUseQuestyCaptcha) {
+    wfLoadExtensions([ 'ConfirmEdit', 'ConfirmEdit/QuestyCaptcha' ]);
+    $wgCaptchaClass = 'QuestyCaptcha';
+    $wgCaptchaQuestions = json_decode($wikiInfo->getSetting('wwCaptchaQuestions'), true);
+} else {
+    wfLoadExtensions([ 'ConfirmEdit', 'ConfirmEdit/ReCaptchaNoCaptcha' ]);
+    $wgCaptchaClass = 'ReCaptchaNoCaptcha';
+    $wgReCaptchaSendRemoteIP = true;
+    $wgReCaptchaSiteKey = getenv('MW_RECAPTCHA_SITEKEY');
+    $wgReCaptchaSecretKey = getenv('MW_RECAPTCHA_SECRETKEY');
+}
 
 # Mailgun
 if ($wwUseMailgunExtension) {


### PR DESCRIPTION
This relies on two new settings being available in the wikiInfo sent from the api:
- wwUseQuestyCaptcha
- wwCaptchaQuestions

Like other settings these are used as-is and are not checked in the settings file. However ConfirmEdit does escape the content which should mean that no additional escaping is necessary.

This does not add much additional code to the image since Questy is part of the ConfirmEdit extension, it just has to be specially loaded.

RecaptchaNoCaptcha remains in use whenever this setting is not enabled.