### PR TITLE
Enable $wgConfirmAccountCaptchas for ConfirmAccount wikis

### DIFF
--- a/dist-persist/wbstack/src/Settings/LocalSettings.php
+++ b/dist-persist/wbstack/src/Settings/LocalSettings.php
@@ -363,6 +363,7 @@ if( $wikiInfo->getSetting('wwExtEnableConfirmAccount') ) {
 
     $wgMakeUserPageFromBio = false;
     $wgAutoWelcomeNewUsers = false;
+    $wgConfirmAccountCaptchas = true;
     $wgConfirmAccountRequestFormItems = [
         'UserName'        => [ 'enabled' => true ],
         'RealName'        => [ 'enabled' => false ],

--- a/dist/wbstack/src/Settings/LocalSettings.php
+++ b/dist/wbstack/src/Settings/LocalSettings.php
@@ -363,6 +363,7 @@ if( $wikiInfo->getSetting('wwExtEnableConfirmAccount') ) {
 
     $wgMakeUserPageFromBio = false;
     $wgAutoWelcomeNewUsers = false;
+    $wgConfirmAccountCaptchas = true;
     $wgConfirmAccountRequestFormItems = [
         'UserName'        => [ 'enabled' => true ],
         'RealName'        => [ 'enabled' => false ],


### PR DESCRIPTION
It looks like unfortunately without this variable being set captchas are not required to request an account on a ConfirmAccount enabled wiki. See both the patch[1], ticket[2] and discussion[3]

[1] https://gerrit.wikimedia.org/r/c/mediawiki/extensions/ConfirmAccount/+/879996
[2] https://phabricator.wikimedia.org/T168783
[3] https://www.mediawiki.org/wiki/Topic:W449yd63slfossl2#flow-post-w457lxnfmrb51gct