### PR TITLE
fix: propagate status code from platform api when routing wiki requests

### DIFF
--- a/.github/workflows/mediawiki.verify.yml
+++ b/.github/workflows/mediawiki.verify.yml
@@ -32,3 +32,7 @@ jobs:
       - run: curl -L -s -N "http://site2.localhost:8001/w/api.php" | grep -q "Main module"
       - run: curl -L -s -N "http://site2.localhost:8001/w/load.php" | grep -q "no modules were requested"
       - run: curl -L -s -N "http://site2.localhost:8001/w/rest.php" | grep -q "did not match any known handler"
+
+      - run: curl -L -s -N "http://notfound.localhost:8001/wiki/Main_Page" | grep -q "It may never have existed"
+
+      - run: curl -L -s -N "http://failwith500.localhost:8001/wiki/Main_Page" | grep -q "server error in the platform API"

--- a/.github/workflows/mediawiki.verify.yml
+++ b/.github/workflows/mediawiki.verify.yml
@@ -36,3 +36,5 @@ jobs:
       - run: curl -L -s -N "http://notfound.localhost:8001/wiki/Main_Page" | grep -q "It may never have existed"
 
       - run: curl -L -s -N "http://failwith500.localhost:8001/wiki/Main_Page" | grep -q "server error in the platform API"
+
+      - run: curl -L -s -N "http://broken.localhost:8001/wiki/Main_Page" | grep -q "server error in the platform API"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Tags have the format: `<MediaWiki core version>-<PHP Version>-<date>-<build number>`
 
+## 1.39-7.4-20240116-0
+- On failure, propagate status code from Platform API to clients (T343744)
+
 ## 1.39-7.4-20240103-0
 - Add QuestyCaptcha config option
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "scripts": {
         "lint": [
             "parallel-lint --exclude ./dist --exclude ./sync/.tmp .",
-            "rc=0 && for x in `find . -not -path './sync/.tmp/*' -not -path './dist/*' -name \"*.json\" -type f`; do vendor/bin/jsonlint \"$x\" || rc=$?; done && exit $rc"
+            "rc=0 && for x in `find . -not -path './sync/.tmp/*' -not -path './dist/*' -name \"*.json\" ! -name \"WikiInfo-broken.json\" -type f`; do vendor/bin/jsonlint \"$x\" || rc=$?; done && exit $rc"
             ]
     }
 }

--- a/dist-persist/wbstack/src/Info/GlobalSet.php
+++ b/dist-persist/wbstack/src/Info/GlobalSet.php
@@ -134,7 +134,11 @@ class GlobalSet {
             return new WBStackLookupFailure($responseCode);
         }
 
-        return WBStackInfo::newFromJsonString($response, $requestDomain);
+        try {
+            return WBStackInfo::newFromJsonString($response, $requestDomain);
+        } catch (\Exception $ex) {
+            return new WBStackLookupFailure(502);
+        }
     }
 
 }

--- a/dist-persist/wbstack/src/Info/GlobalSet.php
+++ b/dist-persist/wbstack/src/Info/GlobalSet.php
@@ -133,6 +133,12 @@ class GlobalSet {
         curl_setopt( $client, CURLOPT_USERAGENT, "WBStack - MediaWiki - WBStackInfo::getInfoFromApi" );
         
         $response = curl_exec($client);
+        if ($response === false) {
+            throw new GlobalSetException(
+                "Unexpected error getting wiki info from api: ".curl_error($client),
+                502,
+            );
+        }
         $responseCode = intval(curl_getinfo($client, CURLINFO_RESPONSE_CODE));
 
         if ($responseCode > 299) {

--- a/dist-persist/wbstack/src/Info/WBStackInfo.php
+++ b/dist-persist/wbstack/src/Info/WBStackInfo.php
@@ -41,7 +41,7 @@ class WBStackInfo
 
         // Check if the string we were given was invalid and thus not parsed!
         if ( $data === null ) {
-            return null;
+            throw new \Exception('Unexpected malformed payload.');
         }
 
         // Get the inner data from the response
@@ -49,7 +49,7 @@ class WBStackInfo
 
         // Data from the api should always be an array with at least an id...
         if (!is_object($data) || !property_exists($data, 'id')) {
-            return null;
+            throw new \Exception('Unexpected payload shape.');
         }
 
         $info = new self($data);

--- a/dist-persist/wbstack/src/Info/WBStackInfo.php
+++ b/dist-persist/wbstack/src/Info/WBStackInfo.php
@@ -75,3 +75,12 @@ class WBStackInfo
     }
 
 }
+
+class WBStackLookupFailure
+{
+    public $statusCode;
+
+    public function __construct($statusCode) {
+        $this->statusCode = $statusCode;
+    }
+}

--- a/dist-persist/wbstack/src/Shim/Cli.php
+++ b/dist-persist/wbstack/src/Shim/Cli.php
@@ -15,7 +15,9 @@ if( getenv( 'WBS_DOMAIN' ) == false ) {
 }
 
 // Try and get the wiki info (from env var) or fail with a message
-if(!\WBStack\Info\GlobalSet::forDomain( getenv( 'WBS_DOMAIN' ) )) {
+try {
+    \WBStack\Info\GlobalSet::forDomain( getenv( 'WBS_DOMAIN' ) );
+} catch (Exception $ex) {
     echo 'Failed to work for WBS_DOMAIN: ' . getenv( 'WBS_DOMAIN' );
     die(1);
 }

--- a/dist-persist/wbstack/src/Shim/Web.php
+++ b/dist-persist/wbstack/src/Shim/Web.php
@@ -2,11 +2,13 @@
 
 require_once __DIR__ . '/../loadShim.php';
 
-// Try and get the wiki info, for fail with a 404 web page
-if(!\WBStack\Info\GlobalSet::forDomain( $_SERVER['SERVER_NAME'] ) ) {
-    http_response_code(404);
+// Try and get the wiki info or fail
+try {
+    \WBStack\Info\GlobalSet::forDomain($_SERVER['SERVER_NAME']);
+} catch (Exception $ex) {
+    http_response_code($ex->getCode());
     echo "You have requested the domain: " . $_SERVER['SERVER_NAME'] . ". But that wiki can not currently be loaded.\n";
-    echo "It may never have existed, or it might now be deleted.\n";
+    echo "It may never have existed, it might now be deleted, or there was a server error.\n";
     die(1);
 }
 

--- a/dist-persist/wbstack/src/Shim/Web.php
+++ b/dist-persist/wbstack/src/Shim/Web.php
@@ -5,10 +5,15 @@ require_once __DIR__ . '/../loadShim.php';
 // Try and get the wiki info or fail
 try {
     \WBStack\Info\GlobalSet::forDomain($_SERVER['SERVER_NAME']);
-} catch (Exception $ex) {
+} catch (\WBStack\Info\GlobalSetException $ex) {
     http_response_code($ex->getCode());
-    echo "You have requested the domain: " . $_SERVER['SERVER_NAME'] . ". But that wiki can not currently be loaded.\n";
-    echo "It may never have existed, it might now be deleted, or there was a server error.\n";
+    echo "You have requested the domain: " . $_SERVER['SERVER_NAME'] . ". But that wiki can not currently be loaded.".PHP_EOL;
+    if ($ex->getCode() === 404) {
+        echo "It may never have existed or it might now be deleted.".PHP_EOL;
+    } else {
+        echo "There was a server error in the platform API.".PHP_EOL;
+    }
+    echo $ex->getMessage();
     die(1);
 }
 

--- a/dist/wbstack/src/Info/GlobalSet.php
+++ b/dist/wbstack/src/Info/GlobalSet.php
@@ -134,7 +134,11 @@ class GlobalSet {
             return new WBStackLookupFailure($responseCode);
         }
 
-        return WBStackInfo::newFromJsonString($response, $requestDomain);
+        try {
+            return WBStackInfo::newFromJsonString($response, $requestDomain);
+        } catch (\Exception $ex) {
+            return new WBStackLookupFailure(502);
+        }
     }
 
 }

--- a/dist/wbstack/src/Info/GlobalSet.php
+++ b/dist/wbstack/src/Info/GlobalSet.php
@@ -133,6 +133,12 @@ class GlobalSet {
         curl_setopt( $client, CURLOPT_USERAGENT, "WBStack - MediaWiki - WBStackInfo::getInfoFromApi" );
         
         $response = curl_exec($client);
+        if ($response === false) {
+            throw new GlobalSetException(
+                "Unexpected error getting wiki info from api: ".curl_error($client),
+                502,
+            );
+        }
         $responseCode = intval(curl_getinfo($client, CURLINFO_RESPONSE_CODE));
 
         if ($responseCode > 299) {

--- a/dist/wbstack/src/Info/WBStackInfo.php
+++ b/dist/wbstack/src/Info/WBStackInfo.php
@@ -41,7 +41,7 @@ class WBStackInfo
 
         // Check if the string we were given was invalid and thus not parsed!
         if ( $data === null ) {
-            return null;
+            throw new \Exception('Unexpected malformed payload.');
         }
 
         // Get the inner data from the response
@@ -49,7 +49,7 @@ class WBStackInfo
 
         // Data from the api should always be an array with at least an id...
         if (!is_object($data) || !property_exists($data, 'id')) {
-            return null;
+            throw new \Exception('Unexpected payload shape.');
         }
 
         $info = new self($data);

--- a/dist/wbstack/src/Info/WBStackInfo.php
+++ b/dist/wbstack/src/Info/WBStackInfo.php
@@ -75,3 +75,12 @@ class WBStackInfo
     }
 
 }
+
+class WBStackLookupFailure
+{
+    public $statusCode;
+
+    public function __construct($statusCode) {
+        $this->statusCode = $statusCode;
+    }
+}

--- a/dist/wbstack/src/Shim/Cli.php
+++ b/dist/wbstack/src/Shim/Cli.php
@@ -15,7 +15,9 @@ if( getenv( 'WBS_DOMAIN' ) == false ) {
 }
 
 // Try and get the wiki info (from env var) or fail with a message
-if(!\WBStack\Info\GlobalSet::forDomain( getenv( 'WBS_DOMAIN' ) )) {
+try {
+    \WBStack\Info\GlobalSet::forDomain( getenv( 'WBS_DOMAIN' ) );
+} catch (Exception $ex) {
     echo 'Failed to work for WBS_DOMAIN: ' . getenv( 'WBS_DOMAIN' );
     die(1);
 }

--- a/dist/wbstack/src/Shim/Web.php
+++ b/dist/wbstack/src/Shim/Web.php
@@ -2,11 +2,13 @@
 
 require_once __DIR__ . '/../loadShim.php';
 
-// Try and get the wiki info, for fail with a 404 web page
-if(!\WBStack\Info\GlobalSet::forDomain( $_SERVER['SERVER_NAME'] ) ) {
-    http_response_code(404);
+// Try and get the wiki info or fail
+try {
+    \WBStack\Info\GlobalSet::forDomain($_SERVER['SERVER_NAME']);
+} catch (Exception $ex) {
+    http_response_code($ex->getCode());
     echo "You have requested the domain: " . $_SERVER['SERVER_NAME'] . ". But that wiki can not currently be loaded.\n";
-    echo "It may never have existed, or it might now be deleted.\n";
+    echo "It may never have existed, it might now be deleted, or there was a server error.\n";
     die(1);
 }
 

--- a/dist/wbstack/src/Shim/Web.php
+++ b/dist/wbstack/src/Shim/Web.php
@@ -5,10 +5,15 @@ require_once __DIR__ . '/../loadShim.php';
 // Try and get the wiki info or fail
 try {
     \WBStack\Info\GlobalSet::forDomain($_SERVER['SERVER_NAME']);
-} catch (Exception $ex) {
+} catch (\WBStack\Info\GlobalSetException $ex) {
     http_response_code($ex->getCode());
-    echo "You have requested the domain: " . $_SERVER['SERVER_NAME'] . ". But that wiki can not currently be loaded.\n";
-    echo "It may never have existed, it might now be deleted, or there was a server error.\n";
+    echo "You have requested the domain: " . $_SERVER['SERVER_NAME'] . ". But that wiki can not currently be loaded.".PHP_EOL;
+    if ($ex->getCode() === 404) {
+        echo "It may never have existed or it might now be deleted.".PHP_EOL;
+    } else {
+        echo "There was a server error in the platform API.".PHP_EOL;
+    }
+    echo $ex->getMessage();
     die(1);
 }
 

--- a/docker-compose/fake-api/WikiInfo-broken.json
+++ b/docker-compose/fake-api/WikiInfo-broken.json
@@ -1,0 +1,1 @@
+{"success":tr

--- a/docker-compose/fake-api/index.php
+++ b/docker-compose/fake-api/index.php
@@ -16,8 +16,15 @@ if( !$domainIsLocalHost ){
 // subdomain is 1 element
 $subdomain = $matches[1];
 
+if ( $subdomain === 'failwith500' ) {
+    http_response_code(500);
+    echo "Internal server error";
+    die(1);
+}
+
 $file = __DIR__ . '/WikiInfo-'.$subdomain.'.json';
 if ( !file_exists($file) ) {
+    http_response_code(404);
     echo 'Requested subdomain does not exist in test data';
     die(1);
 }


### PR DESCRIPTION
Ticket: https://phabricator.wikimedia.org/T343744

I tested this locally by:
- requesting a wiki that does not exist, receiving a 404
- hard coding an error for a certain wiki in api, seeing a 500

```diff
diff --git a/app/Http/Controllers/Backend/WikiController.php b/app/Http/Controllers/Backend/WikiController.php
index 2343cd3..b8469ff 100644
--- a/app/Http/Controllers/Backend/WikiController.php
+++ b/app/Http/Controllers/Backend/WikiController.php
@@ -13,6 +13,9 @@ class WikiController extends Controller
     public function getWikiForDomain(Request $request): \Illuminate\Http\JsonResponse
     {
         $domain = $request->input('domain');
+        if ($domain === 'thirdwiki.wbaas.localhost') {
+            throw \Exception("THE DINOSAURS ESCAPED");
+        }
 
         // XXX: this same logic is in quickstatements.php and platform api WikiController backend
         try {
```