### PR TITLE
Specify a cluster when creating CirrusSearch indices

### DIFF
--- a/dist-persist/wbstack/src/Internal/ApiWbStackElasticSearchInit.php
+++ b/dist-persist/wbstack/src/Internal/ApiWbStackElasticSearchInit.php
@@ -34,8 +34,10 @@ class ApiWbStackElasticSearchInit extends \ApiBase {
     public function getAllowedParams() {
         return [
             'cluster' => [
+                // Value can be 'all' or a CirrusSearch cluster name defined in LocalSettings.php
                 ParamValidator::PARAM_TYPE => 'string',
-                ParamValidator::PARAM_REQUIRED => true
+                ParamValidator::PARAM_REQUIRED => true,
+                ParamValidator::PARAM_DEFAULT => 'all'
             ]
         ];
     }

--- a/dist/wbstack/src/Internal/ApiWbStackElasticSearchInit.php
+++ b/dist/wbstack/src/Internal/ApiWbStackElasticSearchInit.php
@@ -34,8 +34,10 @@ class ApiWbStackElasticSearchInit extends \ApiBase {
     public function getAllowedParams() {
         return [
             'cluster' => [
+                // Value can be 'all' or a CirrusSearch cluster name defined in LocalSettings.php
                 ParamValidator::PARAM_TYPE => 'string',
-                ParamValidator::PARAM_REQUIRED => true
+                ParamValidator::PARAM_REQUIRED => true,
+                ParamValidator::PARAM_DEFAULT => 'all'
             ]
         ];
     }


### PR DESCRIPTION
Example: `curl -l -X POST "http://site1.localhost:8001/w/api.php?action=wbstackElasticSearchInit&cluster=all&format=json"`