### PR TITLE
feat(oauth): when requested, include ConsumerAcceptance in oauth data

### DIFF
--- a/dist-persist/wbstack/src/Internal/ApiWbStackOauthGet.php
+++ b/dist-persist/wbstack/src/Internal/ApiWbStackOauthGet.php
@@ -26,7 +26,8 @@ class ApiWbStackOauthGet extends \ApiBase {
         // Try and get the required consumer
         $consumerData = WbStackPlatformReservedUser::getOAuthConsumer(
             $this->getParameter('consumerName'),
-            $this->getParameter('consumerVersion')
+            $this->getParameter('consumerVersion'),
+            $this->getParameter('includeAccess'),
         );
 
         // If it doesnt exist, make sure the user and consumer do
@@ -42,7 +43,8 @@ class ApiWbStackOauthGet extends \ApiBase {
             );
             $consumerData = WbStackPlatformReservedUser::getOAuthConsumer(
                 $this->getParameter('consumerName'),
-                $this->getParameter('consumerVersion')
+                $this->getParameter('consumerVersion'),
+                $this->getParameter('includeAccess'),
             );
         }
 
@@ -72,6 +74,10 @@ class ApiWbStackOauthGet extends \ApiBase {
             'grants' => [
                 ParamValidator::PARAM_TYPE => 'string',
                 ParamValidator::PARAM_ISMULTI => true,
+            ],
+            'includeAccess' => [
+                ParamValidator::PARAM_TYPE => 'boolean',
+                ParamValidator::PARAM_REQUIRED => false
             ],
             'callbackUrlTail' => [
                 ParamValidator::PARAM_TYPE => 'string',

--- a/dist/wbstack/src/Internal/ApiWbStackOauthGet.php
+++ b/dist/wbstack/src/Internal/ApiWbStackOauthGet.php
@@ -26,7 +26,8 @@ class ApiWbStackOauthGet extends \ApiBase {
         // Try and get the required consumer
         $consumerData = WbStackPlatformReservedUser::getOAuthConsumer(
             $this->getParameter('consumerName'),
-            $this->getParameter('consumerVersion')
+            $this->getParameter('consumerVersion'),
+            $this->getParameter('includeAccess'),
         );
 
         // If it doesnt exist, make sure the user and consumer do
@@ -42,7 +43,8 @@ class ApiWbStackOauthGet extends \ApiBase {
             );
             $consumerData = WbStackPlatformReservedUser::getOAuthConsumer(
                 $this->getParameter('consumerName'),
-                $this->getParameter('consumerVersion')
+                $this->getParameter('consumerVersion'),
+                $this->getParameter('includeAccess'),
             );
         }
 
@@ -72,6 +74,10 @@ class ApiWbStackOauthGet extends \ApiBase {
             'grants' => [
                 ParamValidator::PARAM_TYPE => 'string',
                 ParamValidator::PARAM_ISMULTI => true,
+            ],
+            'includeAccess' => [
+                ParamValidator::PARAM_TYPE => 'boolean',
+                ParamValidator::PARAM_REQUIRED => false
             ],
             'callbackUrlTail' => [
                 ParamValidator::PARAM_TYPE => 'string',


### PR DESCRIPTION
Ticket: https://phabricator.wikimedia.org/T368024

The `transferbot` image relies on `mw-cli` which needs "access" style OAuth credentials in addition to "consumer" ones (as used by magnustools). This PR adds a parameter to the `platformOauthGet` action that includes access credentials on request.

Further down the line this will be called by the Platform API, which will then pass the values to a K8s job running `transferbot` 