### PR TITLE
Add ENV vars for second redis server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Tags have the format: `<MediaWiki core version>-<PHP Version>-<date>-<build number>`
 
+# 1.39-7.4-2024-11-27-0
+- Add parameters for second redis cluster
+
 ## 1.39-7.4-20241114-0
 - Allow users to edit their own CSS and JS (#458)
 - Add VisualEditor extension (#455)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Tags have the format: `<MediaWiki core version>-<PHP Version>-<date>-<build number>`
 
-# 1.39-7.4-2024-11-27-0
+# 1.39-7.4-20241127-0
 - Add parameters for second redis cluster
 
 ## 1.39-7.4-20241114-0

--- a/dist-persist/wbstack/src/Settings/ProductionCache.php
+++ b/dist-persist/wbstack/src/Settings/ProductionCache.php
@@ -15,7 +15,7 @@ $wgParserCacheType = 'db-replicated'; // 'db-replicated' is defined in LocalSett
 // TODO we probably do want a redis connection in some maint scripts...
 if(!$wwDomainIsMaintenance) {
     /** @see RedisBagOStuff for a full explanation of these options. **/
-    $wgMainCacheType = 'redis';
+    $wgMainCacheType = 'redis2'; // See: T380448
     $wgSessionCacheType = 'redis';
     $wgObjectCaches['redis'] = [
         'class' => 'ReplicatedBagOStuff',
@@ -31,6 +31,25 @@ if(!$wwDomainIsMaintenance) {
             'args'  => [ [
                 'class' => 'RedisBagOStuff',
                 'servers' => [ getenv('MW_REDIS_SERVER_WRITE') ]
+            ] ]
+        ],
+        'loggroup'  => 'RedisBagOStuff',
+        'reportDupes' => false
+    ];
+    $wgObjectCaches['redis2'] = [
+        'class' => 'ReplicatedBagOStuff',
+        'readFactory' => [
+            'factory' => [ 'ObjectCache', 'newFromParams' ],
+            'args'  => [ [
+                'class' => 'RedisBagOStuff',
+                'servers' => [ getenv('MW_REDIS_CACHE_SERVER_READ') ]
+            ] ]
+        ],
+        'writeFactory' => [
+            'factory' => [ 'ObjectCache', 'newFromParams' ],
+            'args'  => [ [
+                'class' => 'RedisBagOStuff',
+                'servers' => [ getenv('MW_REDIS_CACHE_SERVER_WRITE') ]
             ] ]
         ],
         'loggroup'  => 'RedisBagOStuff',

--- a/dist/wbstack/src/Settings/ProductionCache.php
+++ b/dist/wbstack/src/Settings/ProductionCache.php
@@ -15,7 +15,7 @@ $wgParserCacheType = 'db-replicated'; // 'db-replicated' is defined in LocalSett
 // TODO we probably do want a redis connection in some maint scripts...
 if(!$wwDomainIsMaintenance) {
     /** @see RedisBagOStuff for a full explanation of these options. **/
-    $wgMainCacheType = 'redis2';
+    $wgMainCacheType = 'redis2'; // See: T380448
     $wgSessionCacheType = 'redis';
     $wgObjectCaches['redis'] = [
         'class' => 'ReplicatedBagOStuff',

--- a/dist/wbstack/src/Settings/ProductionCache.php
+++ b/dist/wbstack/src/Settings/ProductionCache.php
@@ -15,7 +15,7 @@ $wgParserCacheType = 'db-replicated'; // 'db-replicated' is defined in LocalSett
 // TODO we probably do want a redis connection in some maint scripts...
 if(!$wwDomainIsMaintenance) {
     /** @see RedisBagOStuff for a full explanation of these options. **/
-    $wgMainCacheType = 'redis';
+    $wgMainCacheType = 'redis2';
     $wgSessionCacheType = 'redis';
     $wgObjectCaches['redis'] = [
         'class' => 'ReplicatedBagOStuff',
@@ -31,6 +31,25 @@ if(!$wwDomainIsMaintenance) {
             'args'  => [ [
                 'class' => 'RedisBagOStuff',
                 'servers' => [ getenv('MW_REDIS_SERVER_WRITE') ]
+            ] ]
+        ],
+        'loggroup'  => 'RedisBagOStuff',
+        'reportDupes' => false
+    ];
+    $wgObjectCaches['redis2'] = [
+        'class' => 'ReplicatedBagOStuff',
+        'readFactory' => [
+            'factory' => [ 'ObjectCache', 'newFromParams' ],
+            'args'  => [ [
+                'class' => 'RedisBagOStuff',
+                'servers' => [ getenv('MW_REDIS_CACHE_SERVER_READ') ]
+            ] ]
+        ],
+        'writeFactory' => [
+            'factory' => [ 'ObjectCache', 'newFromParams' ],
+            'args'  => [ [
+                'class' => 'RedisBagOStuff',
+                'servers' => [ getenv('MW_REDIS_CACHE_SERVER_WRITE') ]
             ] ]
         ],
         'loggroup'  => 'RedisBagOStuff',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
 
       - MW_REDIS_SERVER_READ=redis.svc
       - MW_REDIS_SERVER_WRITE=redis.svc
+      - MW_REDIS_CACHE_SERVER_READ=redis.svc
+      - MW_REDIS_CACHE_SERVER_WRITE=redis.svc
       - MW_REDIS_PASSWORD=
 
     volumes:


### PR DESCRIPTION
Add ENV vars for a second redis server. This is an attempt to split the kighly volatile main cache from the more stable sessions cache and other users of redis

Bug: T380448