### PR TITLE
fix: local http switch logic

### DIFF
--- a/dist-persist/wbstack/src/Settings/LocalSettings.php
+++ b/dist-persist/wbstack/src/Settings/LocalSettings.php
@@ -29,6 +29,7 @@ $wwDomainIsMaintenance = $wikiInfo->requestDomain === 'maintenance';
 $wwIsPhpUnit = isset( $maintClass ) && $maintClass === 'PHPUnitMaintClass';
 $wwIsLocalisationRebuild = basename( $_SERVER['SCRIPT_NAME'] ) === 'rebuildLocalisationCache.php';
 $wwLocalization = new Localization( $wgExtensionMessagesFiles, $wgMessagesDirs, $wgBaseDirectory, $wwIsLocalisationRebuild );
+$wwDockerCompose = getenv('WBSTACK_DOCKER_COMPOSE') === 'yes';
 
 $wwUseMailgunExtension = true; // default for wbstack
 if (getenv('MW_MAILGUN_DISABLED') === 'yes') {
@@ -93,7 +94,7 @@ if ( getenv('MW_LOG_TO_STDERR') === 'yes' ) {
     ];
 }
 
-if ( $wwDomainSaysLocal ) {
+if ( $wwDockerCompose ) {
     $wgServer = "http://" . $wikiInfo->domain;
 } else {
     $wgServer = "https://" . $wikiInfo->domain;

--- a/dist/wbstack/src/Settings/LocalSettings.php
+++ b/dist/wbstack/src/Settings/LocalSettings.php
@@ -29,6 +29,7 @@ $wwDomainIsMaintenance = $wikiInfo->requestDomain === 'maintenance';
 $wwIsPhpUnit = isset( $maintClass ) && $maintClass === 'PHPUnitMaintClass';
 $wwIsLocalisationRebuild = basename( $_SERVER['SCRIPT_NAME'] ) === 'rebuildLocalisationCache.php';
 $wwLocalization = new Localization( $wgExtensionMessagesFiles, $wgMessagesDirs, $wgBaseDirectory, $wwIsLocalisationRebuild );
+$wwDockerCompose = getenv('WBSTACK_DOCKER_COMPOSE') === 'yes';
 
 $wwUseMailgunExtension = true; // default for wbstack
 if (getenv('MW_MAILGUN_DISABLED') === 'yes') {
@@ -93,7 +94,7 @@ if ( getenv('MW_LOG_TO_STDERR') === 'yes' ) {
     ];
 }
 
-if ( $wwDomainSaysLocal ) {
+if ( $wwDockerCompose ) {
     $wgServer = "http://" . $wikiInfo->domain;
 } else {
     $wgServer = "https://" . $wikiInfo->domain;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     environment:
 
       - WBSTACK_LOAD_MW_INTERNAL=yes # THIS is normally hidden
+      - WBSTACK_DOCKER_COMPOSE=yes
       - PLATFORM_API_BACKEND_HOST=api.svc
 
       - MW_DB_SERVER_MASTER=mysql.svc:3306


### PR DESCRIPTION
Since recently https is used locally in miniikube environments (but not in the docker-compose setup for CI), this adds a small adjustment to only switch to http in that case.

