### PR TITLE
local: fix IP block

### DIFF
--- a/dist-persist/wbstack/src/Settings/LocalSettings.php
+++ b/dist-persist/wbstack/src/Settings/LocalSettings.php
@@ -24,7 +24,7 @@ if ( !defined( 'STDERR' ) ) {
 require_once __DIR__ . '/Localization.php';
 
 // Define some conditions to switch behaviour on
-$wwDomainSaysLocal = preg_match("/(\w\.localhost)/", $_SERVER['SERVER_NAME']) === 1;
+$wwDomainSaysLocal = preg_match("/(\w\.wbaas\.dev)/", $_SERVER['SERVER_NAME']) === 1;
 $wwDomainIsMaintenance = $wikiInfo->requestDomain === 'maintenance';
 $wwIsPhpUnit = isset( $maintClass ) && $maintClass === 'PHPUnitMaintClass';
 $wwIsLocalisationRebuild = basename( $_SERVER['SCRIPT_NAME'] ) === 'rebuildLocalisationCache.php';
@@ -484,6 +484,16 @@ $wgDnsBlacklistUrls =
         'all.s5h.net.',
         'dnsbl.dronebl.org.',
     ];
+
+if ($wwDomainSaysLocal) {
+    $wgProxyWhitelist = [];
+    
+    for ($a=0; $a<255; $a++) {
+        for ($b=0; $b<255; $b++) {
+            $wgProxyWhitelist[] = "10.244.$a.$b";
+        }
+    }
+}
 
 # ConfirmEdit
 

--- a/dist/wbstack/src/Settings/LocalSettings.php
+++ b/dist/wbstack/src/Settings/LocalSettings.php
@@ -24,7 +24,7 @@ if ( !defined( 'STDERR' ) ) {
 require_once __DIR__ . '/Localization.php';
 
 // Define some conditions to switch behaviour on
-$wwDomainSaysLocal = preg_match("/(\w\.localhost)/", $_SERVER['SERVER_NAME']) === 1;
+$wwDomainSaysLocal = preg_match("/(\w\.wbaas\.dev)/", $_SERVER['SERVER_NAME']) === 1;
 $wwDomainIsMaintenance = $wikiInfo->requestDomain === 'maintenance';
 $wwIsPhpUnit = isset( $maintClass ) && $maintClass === 'PHPUnitMaintClass';
 $wwIsLocalisationRebuild = basename( $_SERVER['SCRIPT_NAME'] ) === 'rebuildLocalisationCache.php';
@@ -484,6 +484,16 @@ $wgDnsBlacklistUrls =
         'all.s5h.net.',
         'dnsbl.dronebl.org.',
     ];
+
+if ($wwDomainSaysLocal) {
+    $wgProxyWhitelist = [];
+    
+    for ($a=0; $a<255; $a++) {
+        for ($b=0; $b<255; $b++) {
+            $wgProxyWhitelist[] = "10.244.$a.$b";
+        }
+    }
+}
 
 # ConfirmEdit
 


### PR DESCRIPTION
It seems like some DNS IP blocklist added the private IP range that our minikube setup uses (`10.244.0.1/16`)

Unfortunately we can't set that range directly in $wgProxyWhitelist so I added some loops to build up the IP list ... hopefully we can find a nicer solution but this seems to work at least, so I record it here as a workaround. 

Also this fixes `$wwDomainSaysLocal` as we do not use localhost domains anymore.
  
![image](https://github.com/user-attachments/assets/4c95f112-9726-486a-a690-9d0870468552)
