### PR TITLE
Add $wgMaxExecutionTimeForExpensiveQueries to LocalSetting.php

### DIFF
--- a/dist-persist/wbstack/src/Settings/LocalSettings.php
+++ b/dist-persist/wbstack/src/Settings/LocalSettings.php
@@ -138,6 +138,9 @@ if( !$wwDomainIsMaintenance && !empty(getenv('MW_DB_SERVER_REPLICA'))){
     ];
 }
 
+// Limit expensive queries (T399804)
+$wgMaxExecutionTimeForExpensiveQueries = 5_000;
+
 // Jobs
 # For now jobs will run in the requests, this obviously isn't the ideal solution and really
 # there should be a job running service deployed...

--- a/dist/wbstack/src/Settings/LocalSettings.php
+++ b/dist/wbstack/src/Settings/LocalSettings.php
@@ -138,6 +138,9 @@ if( !$wwDomainIsMaintenance && !empty(getenv('MW_DB_SERVER_REPLICA'))){
     ];
 }
 
+// Limit expensive queries (T399804)
+$wgMaxExecutionTimeForExpensiveQueries = 5_000;
+
 // Jobs
 # For now jobs will run in the requests, this obviously isn't the ideal solution and really
 # there should be a job running service deployed...


### PR DESCRIPTION
Limit max execution time for expensive queries in an attempt to reduce the impact of scrapers on recent changes

Bug: T399804