### PR TITLE
Kartographer: configure OSM Tile Server

### DIFF
--- a/dist-persist/wbstack/src/Settings/LocalSettings.php
+++ b/dist-persist/wbstack/src/Settings/LocalSettings.php
@@ -761,6 +761,9 @@ if ( $wikiInfo->getSetting( 'wwExtEnableElasticSearch' ) ) {
     $wgWBCSElasticErrorFailSilently = true;
 }
 
+// T357047
+$wgKartographerMapServer = 'https://tile.openstreetmap.org';
+$wgKartographerDfltStyle = '';
 
 #######################################
 ## ---  l10n rebuild and beyond  --- ##

--- a/dist/wbstack/src/Settings/LocalSettings.php
+++ b/dist/wbstack/src/Settings/LocalSettings.php
@@ -761,6 +761,9 @@ if ( $wikiInfo->getSetting( 'wwExtEnableElasticSearch' ) ) {
     $wgWBCSElasticErrorFailSilently = true;
 }
 
+// T357047
+$wgKartographerMapServer = 'https://tile.openstreetmap.org';
+$wgKartographerDfltStyle = '';
 
 #######################################
 ## ---  l10n rebuild and beyond  --- ##


### PR DESCRIPTION
- configure openstreetmap tile server for Kartographer extension

as suggested by @addshore (thanks!)

https://phabricator.wikimedia.org/T357047#11920677

tested locally and on staging via image `ghcr.io/deer-wmde/mediawiki:202605161607`

I'm not sure why setting `wgKartographerDfltStyle` to a blank string is needed but it seems to be required.
