### PR TITLE
Add patches to wikiman

### DIFF
--- a/sync/wikiman/wikiman-schema.json
+++ b/sync/wikiman/wikiman-schema.json
@@ -66,6 +66,9 @@
         },
         "remove": {
           "$ref": "#/$defs/RemoveList"
+        },
+        "patches": {
+          "$ref": "#/$defs/PatchList"
         }
       },
       "additionalProperties": false,
@@ -88,6 +91,9 @@
         },
         "remove": {
           "$ref": "#/$defs/RemoveList"
+        },
+        "patches": {
+          "$ref": "#/$defs/PatchList"
         }
       },
       "additionalProperties": false,
@@ -102,6 +108,27 @@
       "items": {
         "type": "string"
       }
+    },
+    "PatchList": {
+      "description": "Patches to apply to the repo",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Patch"
+      }
+    },
+    "Patch": {
+      "description": "A patch to apply (currently only Gerrit base64 patches are supported)",
+      "type": "object",
+      "properties": {
+        "url": {
+          "description": "URL to download the patch from",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "url"
+      ]
     }
   }
 }

--- a/sync/wikiman/wikiman.py
+++ b/sync/wikiman/wikiman.py
@@ -35,8 +35,9 @@ def get_github_url_from_ref(github: Github, ref: str, repository: str):
 
     return f"https://codeload.github.com/{repository}/zip/{commit.sha}"
 
-def make_artifact_entry(details: Dict[str, str], extra_remove: List[str]) -> Dict[str, Any]:
-    name = details['name']
+def make_artifact_entry(details: Dict[str, Any], extra_remove: List[str]) -> Dict[str, Any]:
+    name: str = details['name']
+    patches: List[Dict[str, str]] = details.get('patches', [])
 
     if "repoName" in details.keys():
         artifact_url = get_github_url_from_ref(github_client, details['repoRef'], details['repoName'])
@@ -45,14 +46,14 @@ def make_artifact_entry(details: Dict[str, str], extra_remove: List[str]) -> Dic
     else:
         raise ValueError(f"'repoName' or 'url' key not specified for '{name}' in '{SOURCE_YAMLFILE}'")
 
-    entry = {
+    return {
         'name': name,
         'artifactUrl': artifact_url,
         'artifactLevel': 1,
         'destination': details['destination'],
+        'patchUrls': [patch['url'] for patch in patches],
         'remove' : extra_remove + details.get('remove', []),
     }
-    return entry
 
 # pylint: disable=too-many-ancestors
 class FixedIndentingDumper(yaml.Dumper):
@@ -67,7 +68,8 @@ output: List[Dict] = [make_artifact_entry({
     'repoName': 'wikimedia/mediawiki',
     'repoRef': codebases.get('mediawikiRepoRef', default_branch),
     'destination': './dist',
-    'remove': codebases.get('mediawikiRemove', [])
+    'remove': codebases.get('mediawikiRemove', []),
+    'patches': codebases.get('mediawikiPatches', []),
     }, remove_from_all)]
 
 output += [

--- a/sync/wikiman/wikiman.py
+++ b/sync/wikiman/wikiman.py
@@ -64,23 +64,23 @@ class FixedIndentingDumper(yaml.Dumper):
 default_branch = get_mediawiki_branch_from_version(mediawiki_version) # pylint: disable-msg=C0103
 remove_from_all = codebases.get('removeFromAll', [])
 output: List[Dict] = [make_artifact_entry({
-    'name': 'mediawiki',
-    'repoName': 'wikimedia/mediawiki',
-    'repoRef': codebases.get('mediawikiRepoRef', default_branch),
-    'destination': './dist',
-    'remove': codebases.get('mediawikiRemove', []),
-    'patches': codebases.get('mediawikiPatches', []),
+        'name': 'mediawiki',
+        'repoName': 'wikimedia/mediawiki',
+        'repoRef': codebases.get('mediawikiRepoRef', default_branch),
+        'destination': './dist',
+        'remove': codebases.get('mediawikiRemove', []),
+        'patches': codebases.get('mediawikiPatches', []),
     }, remove_from_all)]
 
 output += [
     make_artifact_entry( {**ext,'destination': f"./dist/extensions/{ext['name']}", 'repoRef': ext.get('repoRef', default_branch)}, remove_from_all )
     for ext in extensions
-    ]
+]
 
 output += [
     make_artifact_entry( {**skin,'destination': f"./dist/skins/{skin['name']}", 'repoRef': skin.get('repoRef', default_branch)}, remove_from_all )
     for skin in skins
-    ]
+]
 
 # write out to the lock.yaml file
 with open(DESTINATION_YAMLFILE, 'w') as outfile:

--- a/wikiman.yaml
+++ b/wikiman.yaml
@@ -48,8 +48,16 @@ extensions:
     repoName: wikimedia/mediawiki-extensions-CirrusSearch
   - name: WikibaseCirrusSearch
     repoName: wikimedia/mediawiki-extensions-WikibaseCirrusSearch
+    patches:
+      # Add a config option to allow ignoring Elasticsearch errors
+      - url: https://gerrit.wikimedia.org/r/changes/mediawiki%2Fextensions%2FWikibaseCirrusSearch~1120939/revisions/2/patch?download
+      # Fallback to EntityTermSearchHelper when no results are found
+      - url: https://gerrit.wikimedia.org/r/changes/mediawiki%2Fextensions%2FWikibaseCirrusSearch~1120941/revisions/1/patch?download
   - name: WikibaseLexemeCirrusSearch
     repoName: wikimedia/mediawiki-extensions-WikibaseLexemeCirrusSearch
+    patches:
+      # Add a config option to allow ignoring Elasticsearch errors
+      - url: https://gerrit.wikimedia.org/r/changes/mediawiki%2Fextensions%2FWikibaseLexemeCirrusSearch~1120949/revisions/1/patch?download
   - name: UniversalLanguageSelector
     repoName: wikimedia/mediawiki-extensions-UniversalLanguageSelector
   - name: cldr
@@ -62,6 +70,9 @@ extensions:
     repoName: wikimedia/mediawiki-extensions-TwoColConflict
   - name: OAuth
     repoName: wikimedia/mediawiki-extensions-OAuth
+    patches:
+      # Remove warning when using OAuth server's URL
+      - url: https://gerrit.wikimedia.org/r/changes/mediawiki%2Fextensions%2FOAuth~1197610/revisions/2/patch?download
   - name: WikibaseLexeme
     repoName: wikimedia/mediawiki-extensions-WikibaseLexeme
   - name: SyntaxHighlight_GeSHi
@@ -92,6 +103,10 @@ extensions:
     repoName: wikimedia/mediawiki-extensions-SecureLinkFixer
   - name: Echo
     repoName: wikimedia/mediawiki-extensions-Echo
+    patches:
+      # Fixes SQLBagOStuff duplicate warnings due to a bug in the Echo extension.
+      # Remove when updated to 1.44+ (Bug: T412100).
+      - url: https://gerrit.wikimedia.org/r/changes/mediawiki%2Fextensions%2FEcho~1093496/revisions/1/patch?download
   - name: Poem
     repoName: wikimedia/mediawiki-extensions-Poem
   - name: TemplateData
@@ -134,6 +149,9 @@ extensions:
   ## These extensions use urls directly
   - name: Wikibase
     url: https://github.com/wbstack/mediawiki-tars/raw/a58eaf2a2c2324649985da8281e264a600d029fc/Wikibase-1782811529-REL1_43.tar.gz
+    patches:
+      # Support for fallback search helpers in CombinedEntitySearchHelper
+      - url: https://gerrit.wikimedia.org/r/changes/mediawiki%2Fextensions%2FWikibase~1120952/revisions/1/patch?download
     remove:
       - build
       - vendor


### PR DESCRIPTION
Allow components (mediawiki, extensions, skins) in `wikiman.yaml` to define patches via a `patches` array. Patches are now preserved when wikiman regenerates `pacman.yaml`, removing the need to manually re-add them. This also makes it easier to add comments explaining what each patch does.

`patches` is an array of objects so that it can support managing patches via different means in the future. E.g. the Patch object could contain a Gerrit Change Number or a Commit Hash instead of the URL.

Bug: T431152